### PR TITLE
(json PR 210) Add u128 compatibility

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut, Deref};
 use std::convert::TryInto;
-use std::{fmt, mem, usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32};
+use std::{fmt, mem, usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32, u128};
 use std::io::{self, Write};
 
 use crate::{Result, Error};
@@ -229,6 +229,12 @@ impl JsonValue {
     }
 
     pub fn as_u64(&self) -> Option<u64> {
+        self.as_number().and_then(|value| {
+            value.try_into().ok()
+        })
+    }
+    
+    pub fn as_u128(&self) -> Option<u128> {
         self.as_number().and_then(|value| {
             value.try_into().ok()
         })


### PR DESCRIPTION
https://github.com/maciejhirsz/json-rust/pull/210

This is a good start, but doesn't compile because of a missing trait, therefore just a draft for now:
![Screenshot from 2023-08-25 18-57-12](https://github.com/rustadopt/jzon-rs/assets/49617392/65c58fa6-e1e3-4376-a583-a92f4792dbca)
