### PR TITLE
Fix overflow from i64::MIN

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -440,7 +440,7 @@ macro_rules! impl_signed {
                     Number {
                         category: NEGATIVE,
                         exponent: 0,
-                        mantissa: -num as u64,
+                        mantissa: num.wrapping_neg() as u64,
                     }
                 } else {
                     Number {


### PR DESCRIPTION
`wrapping_neg` has the correct behavior, and avoids `- num` from crashing with an overflow error in debug builds in `jzon::number::Number::from(i64::MIN)`.